### PR TITLE
Sobrescrita do método AddFile

### DIFF
--- a/src/RESTRequest4D.Request.Client.pas
+++ b/src/RESTRequest4D.Request.Client.pas
@@ -59,7 +59,8 @@ type
     function ContentType(const AContentType: string): IRequest;
     function UserAgent(const AName: string): IRequest;
     function AddCookies(const ACookies: TStrings): IRequest;
-    function AddFile(const AName: string; const AValue: TStream): IRequest;
+    function AddFile(const AName: string; const AValue: TStream): IRequest; overload;
+    function AddFile(const AName: string; const APath: string): IRequest; overload;
     function Proxy(const AServer, APassword, AUsername: string; const APort: Integer): IRequest;
     function DeactivateProxy: IRequest;
   protected
@@ -508,6 +509,27 @@ begin
   Result := Self;
   for I := 0 to Pred(ACookies.Count) do
     FRESTRequest.AddParameter(ACookies.Names[I], ACookies.Values[ACookies.Names[I]], TRESTRequestParameterKind.pkCOOKIE);
+end;
+
+function TRequestClient.AddFile(const AName, APath: string): IRequest;
+var
+  LParams: TRESTRequestParameterList;
+begin
+  Result := Self;
+  LParams := TRESTRequestParameterList.Create(nil);
+  try
+    with LParams.AddItem do
+    begin
+      Kind := pkFile;
+      Name := AName;
+      Value := APath;
+      Options := [poDoNotEncode];
+      ContentType := ctMULTIPART_FORM_DATA;
+    end;
+    FRESTRequest.Params := LParams;
+  finally
+    FreeAndNil(LParams);
+  end;
 end;
 
 end.

--- a/src/RESTRequest4D.Request.Contract.pas
+++ b/src/RESTRequest4D.Request.Contract.pas
@@ -65,7 +65,8 @@ type
     function UserAgent(const AName: string): IRequest;
     function ContentType(const AContentType: string): IRequest;
     function AddCookies(const ACookies: TStrings): IRequest;
-    function AddFile(const AName: string; const AValue: TStream): IRequest;
+    function AddFile(const AName: string; const AValue: TStream): IRequest; overload;
+    function AddFile(const AName: string; const APath: string): IRequest; overload;
     function Proxy(const AServer, APassword, AUsername: string; const APort: Integer): IRequest;
     function DeactivateProxy: IRequest;
   end;


### PR DESCRIPTION
Uma forma de enviar arquivo passando o Path em vez de uma Stream.

ps. Dessa forma, ao precisar usar o AddFile, ele deve ser chamado antes do AddHeader, Token e de outros métodos que façam chamada ao FRESTRequest.Params. Por exemplo: 
`TRequest.New.BaseURL('http://127.0.0.1:9000/up')
   .AddFile('arquivos',APathFile)
     .Token('bearer ' + FToken)
       .Post;`