### PR TITLE
Erro "no mapping for the unicode character exists in the target multi-byte code page"

### DIFF
--- a/src/RESTRequest4D.Request.Client.pas
+++ b/src/RESTRequest4D.Request.Client.pas
@@ -51,6 +51,7 @@ type
     function AddBody(const AContent: TJSONArray; const AOwns: Boolean = True): IRequest; overload;
     function AddBody(const AContent: TObject; const AOwns: Boolean = True): IRequest; overload;
     function AddBody(const AContent: TStream; const AOwns: Boolean = True): IRequest; overload;
+    function FallbackCharsetEncoding(const aFallbackCharsetEncoding : String) : IRequest;
     function AddUrlSegment(const AName, AValue: string): IRequest;
     function SynchronizedEvents(const AValue: Boolean): IRequest;
     function ClearHeaders: IRequest;
@@ -327,6 +328,13 @@ end;
 function TRequestClient.DataSetAdapter: TDataSet;
 begin
   Result := FDataSetAdapter;
+end;
+
+function TRequestClient.FallbackCharsetEncoding(
+  const aFallbackCharsetEncoding: String): IRequest;
+begin
+  Result := Self;
+  FRESTClient.FallbackCharsetEncoding := aFallbackCharsetEncoding;
 end;
 
 function TRequestClient.FullRequestURL(const AIncludeParams: Boolean): string;

--- a/src/RESTRequest4D.Request.Contract.pas
+++ b/src/RESTRequest4D.Request.Contract.pas
@@ -54,6 +54,8 @@ type
     function AddHeader(const AName, AValue: string; const AOptions: TRESTRequestParameterOptions = []): IRequest;
     function AddParam(const AName, AValue: string; const AKind: TRESTRequestParameterKind = {$IF COMPILERVERSION < 33}TRESTRequestParameterKind.pkGETorPOST{$ELSE}TRESTRequestParameterKind.pkQUERY{$ENDIF}): IRequest;
     function AddBody(const AContent: string; const AContentType: TRESTContentType = ctAPPLICATION_JSON): IRequest; overload;
+    function FallbackCharsetEncoding(const aFallbackCharsetEncoding : String) : IRequest;
+    function
     {$ENDIF}
     function AddBody(const AContent: TJSONObject; const AOwns: Boolean = True): IRequest; overload;
     function AddBody(const AContent: TJSONArray; const AOwns: Boolean = True): IRequest; overload;

--- a/src/RESTRequest4D.Request.Contract.pas
+++ b/src/RESTRequest4D.Request.Contract.pas
@@ -55,7 +55,6 @@ type
     function AddParam(const AName, AValue: string; const AKind: TRESTRequestParameterKind = {$IF COMPILERVERSION < 33}TRESTRequestParameterKind.pkGETorPOST{$ELSE}TRESTRequestParameterKind.pkQUERY{$ENDIF}): IRequest;
     function AddBody(const AContent: string; const AContentType: TRESTContentType = ctAPPLICATION_JSON): IRequest; overload;
     function FallbackCharsetEncoding(const aFallbackCharsetEncoding : String) : IRequest;
-    function
     {$ENDIF}
     function AddBody(const AContent: TJSONObject; const AOwns: Boolean = True): IRequest; overload;
     function AddBody(const AContent: TJSONArray; const AOwns: Boolean = True): IRequest; overload;


### PR DESCRIPTION
Foi implementada a função "FallbackCharsetEncoding" para que não dê esse estouro de memória quando no bory vir caracteres diferentes de UTF-8.
