### PR TITLE
Problema na warning para Android

### DIFF
--- a/boss-lock.json
+++ b/boss-lock.json
@@ -1,11 +1,11 @@
 {
-	"hash": "cdbb70a8679a51d4358a9e31e1ef566a",
-	"updated": "2021-03-24T15:27:46.0150426-03:00",
+	"hash": "",
+	"updated": "2021-09-30T18:04:36.4864431-03:00",
 	"installedModules": {
-		"github.com/viniciussanchez/dataset-serialize": {
+		"https://github.com/ricksolucoes/dataset-serialize": {
 			"name": "dataset-serialize",
-			"version": "v2.3.3",
-			"hash": "65a1995f3a283f09382722a7a8c21d1a",
+			"version": "2.3.3",
+			"hash": "3d8342c46cb68d82bf100b8e5c2623b2",
 			"artifacts": {},
 			"failed": false,
 			"changed": false

--- a/boss.json
+++ b/boss.json
@@ -6,6 +6,6 @@
 	"mainsrc": "src",
 	"projects": [],
 	"dependencies": {
-		"github.com/viniciussanchez/dataset-serialize": "^v2.2.9"
+		"https://github.com/ricksolucoes/dataset-serialize": "^2.3.3"
 	}
 }

--- a/src/RESTRequest4D.Request.Client.pas
+++ b/src/RESTRequest4D.Request.Client.pas
@@ -102,7 +102,11 @@ begin
     FRESTRequest.Body.Add(AContent);
   {$ENDIF}
   if AOwns then
+    {$IFDEF MSWINDOWS}
     AContent.Free;
+    {$ELSEIFDEF}
+      AContent.DisposeOf;
+    {$ENDIF}
 end;
 
 function TRequestClient.AddBody(const AContent: TJSONArray; const AOwns: Boolean): IRequest;
@@ -112,7 +116,11 @@ begin
     Exit;
   Self.AddBody(AContent.ToString);
   if AOwns then
+    {$IFDEF MSWINDOWS}
     AContent.Free;
+    {$ELSEIFDEF}
+    AContent.DisposeOf;
+    {$ENDIF}
 end;
 
 function TRequestClient.AddBody(const AContent: TObject; const AOwns: Boolean): IRequest;
@@ -126,7 +134,11 @@ begin
     FRESTRequest.Body.Add(AContent);
   {$ENDIF}
   if AOwns then
+    {$IFDEF MSWINDOWS}
     AContent.Free;
+    {$ELSEIFDEF}
+    AContent.DisposeOf;
+    {$ENDIF}
 end;
 
 function TRequestClient.AddFile(const AName: string; const AValue: TStream): IRequest;
@@ -515,7 +527,11 @@ begin
     FRESTRequest.Body.Add(AContent, TRESTContentType.ctAPPLICATION_OCTET_STREAM);
   {$ENDIF}
   if AOwns then
+    {$IFDEF MSWINDOWS}
     AContent.Free;
+    {$ELSEIFDEF}
+    AContent.DisposeOf;
+    {$ENDIF}
 end;
 
 function TRequestClient.AddCookies(const ACookies: TStrings): IRequest;

--- a/src/RESTRequest4D.Request.Client.pas
+++ b/src/RESTRequest4D.Request.Client.pas
@@ -104,7 +104,7 @@ begin
   if AOwns then
     {$IFDEF MSWINDOWS}
     AContent.Free;
-    {$ELSEIFDEF}
+    {$ELSE}
       AContent.DisposeOf;
     {$ENDIF}
 end;
@@ -118,7 +118,7 @@ begin
   if AOwns then
     {$IFDEF MSWINDOWS}
     AContent.Free;
-    {$ELSEIFDEF}
+    {$ELSE}
     AContent.DisposeOf;
     {$ENDIF}
 end;
@@ -136,7 +136,7 @@ begin
   if AOwns then
     {$IFDEF MSWINDOWS}
     AContent.Free;
-    {$ELSEIFDEF}
+    {$ELSE}
     AContent.DisposeOf;
     {$ENDIF}
 end;
@@ -529,7 +529,7 @@ begin
   if AOwns then
     {$IFDEF MSWINDOWS}
     AContent.Free;
-    {$ELSEIFDEF}
+    {$ELSE}
     AContent.DisposeOf;
     {$ENDIF}
 end;


### PR DESCRIPTION
Criado uma diretriz para quando não for o Windows utilizar o Disposeof, por que no Android quando utilizado o Free ele gera um worning.