### PR TITLE
Add SecureProtocol RESTClient

### DIFF
--- a/src/RESTRequest4D.Request.Client.pas
+++ b/src/RESTRequest4D.Request.Client.pas
@@ -3,7 +3,7 @@ unit RESTRequest4D.Request.Client;
 interface
 
 uses RESTRequest4D.Request.Contract, Data.DB, REST.Client, REST.Response.Adapter, REST.Types, System.SysUtils, System.Classes,
-  RESTRequest4D.Response.Contract, System.JSON, REST.Authenticator.Basic{$if CompilerVersion <= 32.0}, IPPeerClient{$endif};
+  RESTRequest4D.Response.Contract, System.JSON, System.Net.HttpClient, REST.Authenticator.Basic{$if CompilerVersion <= 32.0}, IPPeerClient{$endif};
 
 type
   TRequestClient = class(TInterfacedObject, IRequest)
@@ -229,6 +229,8 @@ begin
 
   FRESTClient := TRESTClient.Create(nil);
   FRESTClient.SynchronizedEvents := False;
+  FRESTClient.SecureProtocols := [THTTPSecureProtocol.SSL3,THTTPSecureProtocol.TLS1,THTTPSecureProtocol.TLS11,THTTPSecureProtocol.TLS12];
+
 
   FRESTRequest := TRESTRequest.Create(nil);
   FRESTRequest.SynchronizedEvents := False;


### PR DESCRIPTION
Em maquinas com sistema operacional Windows 7, 8 e 8.1, causava um erro: "REST request failed: Error sending data: (12175) Erro de segurança"