### PR TITLE
fix filename is "TFileStream" and no extension

### DIFF
--- a/src/RESTRequest4D.Request.Client.pas
+++ b/src/RESTRequest4D.Request.Client.pas
@@ -66,7 +66,7 @@ type
     function UserAgent(const AName: string): IRequest;
     function AddCookies(const ACookies: TStrings): IRequest;
     function AddCookie(const ACookieName, ACookieValue: string): IRequest;	
-    function AddFile(const AName: string; const AValue: TStream): IRequest;
+    function AddFile(const AName: string; const AValue: TFileStream): IRequest;
     function Proxy(const AServer, APassword, AUsername: string; const APort: Integer): IRequest;
     function DeactivateProxy: IRequest;
   protected
@@ -151,7 +151,7 @@ begin
   end;
 end;
 
-function TRequestClient.AddFile(const AName: string; const AValue: TStream): IRequest;
+function TRequestClient.AddFile(const AName: string; const AValue: TFileStream): IRequest;
 begin
   Result := Self;
   if not Assigned(AValue) then
@@ -161,7 +161,7 @@ begin
   begin
     Name := AName;
     SetStream(AValue);
-    Value := AValue.ToString;
+    Value := AValue.FileName;
     Kind := TRESTRequestParameterKind.pkFILE;
     ContentType := TRESTContentType.ctAPPLICATION_OCTET_STREAM;
   end;

--- a/src/RESTRequest4D.Request.Contract.pas
+++ b/src/RESTRequest4D.Request.Contract.pas
@@ -69,7 +69,7 @@ type
     function ContentType(const AContentType: string): IRequest;
     function AddCookies(const ACookies: TStrings): IRequest;
     function AddCookie(const ACookieName, ACookieValue: string): IRequest;
-    function AddFile(const AName: string; const AValue: TStream): IRequest;
+    function AddFile(const AName: string; const AValue: TFileStream): IRequest;
     function Proxy(const AServer, APassword, AUsername: string; const APort: Integer): IRequest;
     function DeactivateProxy: IRequest;
   end;


### PR DESCRIPTION
The filename is sent as "TStream" with no extension.

Discord API example

- Before
![Captura de tela 2022-05-02 182654](https://user-images.githubusercontent.com/43503837/166330796-d0a1fb71-d2e8-43cc-bcc6-9093cb31da6d.png)

- After
![Captura de tela 2022-05-02 182222](https://user-images.githubusercontent.com/43503837/166330823-ae0e95ff-7172-4f45-93bf-c1f5cd293b17.png)
