### PR TITLE
bugfix-http-version

### DIFF
--- a/src/RESTRequest4D.Request.Indy.pas
+++ b/src/RESTRequest4D.Request.Indy.pas
@@ -595,6 +595,7 @@ begin
   Self.ContentType('application/json');
   FRetries := 0;
   FIdMultiPartFormDataStream := TIdMultiPartFormDataStream.Create;
+  FIdHTTP.HTTPOptions:= [hoKeepOrigProtocol];
 end;
 
 destructor TRequestIndy.Destroy;


### PR DESCRIPTION
I had some issues consuming an API that requires http 1.1. The requests sent through Indy engine uses http 1.0 only. This pull request solves this issue.