### PR TITLE
Ajuste na função do content do motor NetHTTP.

### DIFF
--- a/src/RESTRequest4D.Response.NetHTTP.pas
+++ b/src/RESTRequest4D.Response.NetHTTP.pas
@@ -51,7 +51,7 @@ end;
 function TResponseNetHTTP.Content: string;
 begin
   if Assigned(FHTTPResponse) then
-    Result := FHTTPResponse.ContentAsString;
+    Result := TStringStream(FHTTPResponse.ContentStream).DataString;
 end;
 
 function TResponseNetHTTP.ContentEncoding: string;


### PR DESCRIPTION
Após tentar realizar um POST e uma api me deparei com um erro de “Invalid encoding name”.

Após analise e testes percebi que o problema estava na função Content do motor NetHTTP. Na análise, comparei o retorno dele com o retorno do motor do Indy. Foi nesse momento, que foi percebido que a função content do Indy trata o retorno com a possibilidade do mesmo ser um stream, convertendo-o para string usando TStreamString.DataString,  já o motor NetHTTP não faz tal tratativa, mesmo tendo essa possibilidade. Com isso, foi realizado a alteração do result da função para que o content do NetHTTP tenha o mesmo comportamento do motor Indy.