### PR TITLE
Feature/fix deps indy

### DIFF
--- a/src/RESTRequest4D.Request.Client.pas
+++ b/src/RESTRequest4D.Request.Client.pas
@@ -4,7 +4,7 @@ interface
 
 uses RESTRequest4D.Request.Contract, Data.DB, REST.Client, REST.Response.Adapter, REST.Types, System.SysUtils, System.Classes,
   RESTRequest4D.Response.Contract, System.JSON{$IF COMPILERVERSION >= 33.0}, System.Net.HttpClient{$ENDIF},
-  REST.Authenticator.Basic {$IF COMPILERVERSION <= 32.0}, IPPeerClient, IPPeerCommon{$ENDIF},
+  REST.Authenticator.Basic {$IF COMPILERVERSION <= 32.0}{$IF DEFINED(RR4D_INDY)}, IPPeerClient, IPPeerCommon{$ENDIF}{$ENDIF},
   RESTRequest4D.Request.Adapter.Contract;
 
 type

--- a/src/RESTRequest4D.Response.Client.pas
+++ b/src/RESTRequest4D.Response.Client.pas
@@ -40,14 +40,21 @@ begin
 end;
 
 function TResponseClient.GetCookie(const ACookieName: string): string;
+{$IF CompilerVersion > 28.0}
 var
   I: Integer;
+{$IFEND}
 begin
+  {$IF CompilerVersion > 28.0}
   for I := 0 to Pred(FRESTResponse.Cookies.Count) do
   begin
     if Trim(LowerCase(ACookieName)) = Trim(LowerCase(FRESTResponse.Cookies.Items[I].Name)) then
       Result := FRESTResponse.Cookies.Items[I].Value;
   end;
+  {$ELSE}
+  raise Exception.Create('GetCookie is not supported in Delphi version.');
+  {$IFEND}
+
 end;
 
 function TResponseClient.Content: string;

--- a/src/RESTRequest4D.Response.Client.pas
+++ b/src/RESTRequest4D.Response.Client.pas
@@ -54,7 +54,6 @@ begin
   {$ELSE}
   raise Exception.Create('GetCookie is not supported in Delphi version.');
   {$IFEND}
-
 end;
 
 function TResponseClient.Content: string;


### PR DESCRIPTION
Fix dependencia das indy nao necesaria quando se utiliza o componente apenas con "Request.Client".