### PR TITLE
Fix compatibility version with Timeout

### DIFF
--- a/src/RESTRequest4D.Request.Client.pas
+++ b/src/RESTRequest4D.Request.Client.pas
@@ -437,7 +437,11 @@ end;
 
 function TRequestClient.Timeout: Integer;
 begin
+  {$IF COMPILERVERSION <= 32.0}
+  Result := FRESTRequest.Timeout;
+  {$ELSE}
   Result := FRESTRequest.ConnectTimeout;
+  {$ENDIF}
 end;
 
 function TRequestClient.Patch: IResponse;
@@ -547,8 +551,13 @@ end;
 function TRequestClient.Timeout(const ATimeout: Integer): IRequest;
 begin
   Result := Self;
+
+  {$IF COMPILERVERSION <= 32.0}
+  FRESTRequest.Timeout := ATimeout;
+  {$ELSE}
   FRESTRequest.ConnectTimeout := ATimeout;
   FRESTRequest.ReadTimeout := ATimeout;
+  {$ENDIF}
 end;
 
 function TRequestClient.Token(const AToken: string): IRequest;


### PR DESCRIPTION
Adicionado a condição {$IF COMPILERVERSION <= 32.0} para compatibilidade da função Timeout com versão do Delphi Tokyo ou anteriores.