### PR TITLE
Fix compatibility version with Timeout

### DIFF
--- a/src/RESTRequest4D.Request.Client.pas
+++ b/src/RESTRequest4D.Request.Client.pas
@@ -437,7 +437,7 @@ end;
 
 function TRequestClient.Timeout: Integer;
 begin
-  {$IF COMPILERVERSION <= 32}
+  {$IF COMPILERVERSION <= 33}
     Result := FRESTRequest.Timeout;
   {$ELSE}
     Result := FRESTRequest.ConnectTimeout;
@@ -551,7 +551,7 @@ end;
 function TRequestClient.Timeout(const ATimeout: Integer): IRequest;
 begin
   Result := Self;
-  {$IF COMPILERVERSION <= 32}
+  {$IF COMPILERVERSION <= 33}
     FRESTRequest.Timeout := ATimeout;
   {$ELSE}
     FRESTRequest.ConnectTimeout := ATimeout;


### PR DESCRIPTION
Adicionado a condição {$IF COMPILERVERSION <= 33} para compatibilidade da função Timeout com versão do Delphi Rio ou anteriores.