### PR TITLE
Add Method PATCH no TFPHTTPClient FPC

### DIFF
--- a/src/RESTRequest4D.Request.FPHTTPClient.pas
+++ b/src/RESTRequest4D.Request.FPHTTPClient.pas
@@ -171,7 +171,7 @@ begin
           mrPUT:
             FFPHTTPClient.Put(MakeURL, FResponse.ContentStream);
           mrPATCH:
-            FFPHTTPClient.Put(MakeURL, FResponse.ContentStream);
+            FFPHTTPClient.HTTPMethod('PATCH', MakeURL, FResponse.ContentStream, []);
           mrDELETE:
             FFPHTTPClient.Delete(MakeURL, FResponse.ContentStream);
         end;


### PR DESCRIPTION
Tive um problema em um endpoint "PATCH" e verifiquei que o FPHTTPClient, para Lazarus estava utilizando "PUT".
Acredito que seja a solução, para mim funcionou sem maiores problemas.

de:
mrPATCH:
  FFPHTTPClient.Put(MakeURL, FResponse.ContentStream);

para:
mrPATCH:
  FFPHTTPClient.HTTPMethod('PATCH', MakeURL, FResponse.ContentStream, []);

Att.