### PR TITLE
Update RESTRequest4D.Request.Indy.pas

### DIFF
--- a/src/RESTRequest4D.Request.Indy.pas
+++ b/src/RESTRequest4D.Request.Indy.pas
@@ -240,6 +240,10 @@ procedure TRequestIndy.ExecuteRequest(const AMethod: TMethodRequest);
 var
   LAttempts: Integer;
 begin
+  if not FBaseURL.ToUpper.Trim.StartsWith('HTTPS') then
+    FIdHTTP.IOHandler := nil
+  else
+    FIdHTTP.IOHandler := FIdSSLIOHandlerSocketOpenSSL;
   LAttempts := FRetries + 1;
   while LAttempts > 0 do
   begin


### PR DESCRIPTION
While Indy and no SSL (only HTTP) shouldn't use IOHandler