### PR TITLE
fix: Engine "RR4D_INDY" estava permitindo adicionar Herders duplicado…

### DIFF
--- a/src/RESTRequest4D.Request.Indy.pas
+++ b/src/RESTRequest4D.Request.Indy.pas
@@ -366,7 +366,7 @@ begin
     Exit;
   if FHeaders.IndexOf(AName) < 0 then
     FHeaders.Add(AName);
-  FIdHTTP.Request.CustomHeaders.AddValue(AName, AValue);
+  FIdHTTP.Request.CustomHeaders.Values[AName] := AValue;
 end;
 
 function TRequestIndy.Token(const AToken: string): IRequest;


### PR DESCRIPTION
Corrigido para editar, caso já exista.

[Issue 192](https://github.com/viniciussanchez/RESTRequest4Delphi/issues/192)