### PR TITLE
Parse JSON Encoding Config

### DIFF
--- a/src/RESTRequest4D.Config.pas
+++ b/src/RESTRequest4D.Config.pas
@@ -1,0 +1,56 @@
+unit RESTRequest4D.Config;
+
+interface
+
+uses
+{$IF DEFINED(FPC)}
+  SysUtils;
+{$ELSE}
+  System.SysUtils;
+{$ENDIF}
+
+type
+  TRESTRequest4DConfig = class
+  private
+    FParseJSONEncoding: TEncoding;
+    class var FInstance: TRESTRequest4DConfig;
+  protected
+    class function GetDefaultInstance: TRESTRequest4DConfig;
+  public
+    constructor Create;
+    property ParseJSONEncoding: TEncoding read FParseJSONEncoding write FParseJSONEncoding;
+    class function GetInstance: TRESTRequest4DConfig;
+    class procedure UnInitialize;
+  end;
+
+implementation
+
+constructor TRESTRequest4DConfig.Create;
+begin
+  FParseJSONEncoding := TEncoding.UTF8;
+end;
+
+class function TRESTRequest4DConfig.GetDefaultInstance: TRESTRequest4DConfig;
+begin
+  if not Assigned(FInstance) then
+    FInstance := TRESTRequest4DConfig.Create;
+  Result := FInstance;
+end;
+
+class function TRESTRequest4DConfig.GetInstance: TRESTRequest4DConfig;
+begin
+  Result := TRESTRequest4DConfig.GetDefaultInstance;
+end;
+
+class procedure TRESTRequest4DConfig.UnInitialize;
+begin
+  if Assigned(FInstance) then
+    FreeAndNil(FInstance);
+end;
+
+initialization
+
+finalization
+  TRESTRequest4DConfig.UnInitialize;
+
+end.

--- a/src/RESTRequest4D.Response.Indy.pas
+++ b/src/RESTRequest4D.Response.Indy.pas
@@ -6,7 +6,7 @@ unit RESTRequest4D.Response.Indy;
 
 interface
 
-uses RESTRequest4D.Response.Contract, IdHTTP,
+uses RESTRequest4D.Response.Contract, RESTRequest4D.Config, IdHTTP,
   {$IFDEF FPC}
     SysUtils, fpjson, Classes, jsonparser;
   {$ELSE}
@@ -78,9 +78,9 @@ begin
   begin
     LContent := Content.Trim;
     if LContent.StartsWith('{') then
-      FJSONValue := (TJSONObject.ParseJSONValue(TEncoding.ASCII.GetBytes(LContent), 0) as TJSONObject)
+      FJSONValue := (TJSONObject.ParseJSONValue(TRESTRequest4DConfig.GetInstance.ParseJSONEncoding.GetBytes(LContent), 0) as TJSONObject)
     else if LContent.StartsWith('[') then
-      FJSONValue := (TJSONObject.ParseJSONValue(TEncoding.ASCII.GetBytes(LContent), 0) as TJSONArray)
+      FJSONValue := (TJSONObject.ParseJSONValue(TRESTRequest4DConfig.GetInstance.ParseJSONEncoding.GetBytes(LContent), 0) as TJSONArray)
     else
       raise Exception.Create('The return content is not a valid JSON value.');
   end;

--- a/src/RESTRequest4D.Response.NetHTTP.pas
+++ b/src/RESTRequest4D.Response.NetHTTP.pas
@@ -3,7 +3,7 @@ unit RESTRequest4D.Response.NetHTTP;
 interface
 
 uses RESTRequest4D.Response.Contract, System.Net.HttpClientComponent, System.Net.HttpClient, System.Net.URLClient,
-  System.SysUtils, System.JSON, System.Classes;
+  System.SysUtils, System.JSON, System.Classes, RESTRequest4D.Config;
 
 type
   TResponseNetHTTP = class(TInterfacedObject, IResponse)
@@ -42,9 +42,9 @@ begin
     if Assigned(FHTTPResponse) then
       LContent := FHTTPResponse.ContentAsString.Trim;
     if LContent.StartsWith('{') then
-      FJSONValue := (TJSONObject.ParseJSONValue(TEncoding.ASCII.GetBytes(LContent), 0) as TJSONObject)
+      FJSONValue := (TJSONObject.ParseJSONValue(TRESTRequest4DConfig.GetInstance.ParseJSONEncoding.GetBytes(LContent), 0) as TJSONObject)
     else if LContent.StartsWith('[') then
-      FJSONValue := (TJSONObject.ParseJSONValue(TEncoding.ASCII.GetBytes(LContent), 0) as TJSONArray)
+      FJSONValue := (TJSONObject.ParseJSONValue(TRESTRequest4DConfig.GetInstance.ParseJSONEncoding.GetBytes(LContent), 0) as TJSONArray)
     else
       raise Exception.Create('The return content is not a valid JSON value.');
   end;

--- a/src/RESTRequest4D.Response.Synapse.pas
+++ b/src/RESTRequest4D.Response.Synapse.pas
@@ -6,7 +6,7 @@ unit RESTRequest4D.Response.Synapse;
 
 interface
 
-uses Classes, SysUtils, RESTRequest4D.Response.Contract, httpsend, ssl_openssl,
+uses Classes, SysUtils, RESTRequest4D.Response.Contract, RESTRequest4D.Config, httpsend, ssl_openssl,
   {$IFDEF FPC}
     fpjson, jsonparser;
   {$ELSE}
@@ -112,9 +112,9 @@ begin
   begin
     LContent := Content.Trim;
     if LContent.StartsWith('{') then
-      FJSONValue := (TJSONObject.ParseJSONValue(TEncoding.ASCII.GetBytes(LContent), 0) as TJSONObject)
+      FJSONValue := (TJSONObject.ParseJSONValue(TRESTRequest4DConfig.GetInstance.ParseJSONEncoding.GetBytes(LContent), 0) as TJSONObject)
     else if LContent.StartsWith('[') then
-      FJSONValue := (TJSONObject.ParseJSONValue(TEncoding.ASCII.GetBytes(LContent), 0) as TJSONArray)
+      FJSONValue := (TJSONObject.ParseJSONValue(TRESTRequest4DConfig.GetInstance.ParseJSONEncoding.GetBytes(LContent), 0) as TJSONArray)
     else
       raise Exception.Create('The return content is not a valid JSON value.');
   end;


### PR DESCRIPTION
- Criado config para definir o encoding na hora do parse do json.
- Definido o encoding padrão como UTF8, devido a maioria esmagadora dos usuários aderentes ao RestRequest4D serem adeptos a esse encoding, e também a relatos de problemas com o uso do ASCII quando em dispositivos mobiles.