### PR TITLE
issue #229 - não limpar headers na engine synapse

### DIFF
--- a/src/RESTRequest4D.Response.Synapse.pas
+++ b/src/RESTRequest4D.Response.Synapse.pas
@@ -139,7 +139,6 @@ constructor TResponseSynapse.Create(const AHTTPSend: THTTPSend);
 begin
   FHTTPSend := AHTTPSend;
   FHTTPSend.KeepAlive := True;
-  FHTTPSend.Headers.Clear;
   FStreamResult := TStringStream.Create;
 end;
 


### PR DESCRIPTION
eu mudei o código no create da unit RESTRequest4D.Response.Synapse para não limpar os headers da requisição