### PR TITLE
Ajuste para upload de múltiplos arquivos em Lazarus

### DIFF
--- a/src/RESTRequest4D.Request.FPHTTPClient.pas
+++ b/src/RESTRequest4D.Request.FPHTTPClient.pas
@@ -163,7 +163,9 @@ begin
               LContent := LContent + Format('Content-Disposition: form-data; name="%s"; filename="%s"' + _CRLF, [LFieldName, ExtractFileName(LFile.FFileName)]);
               LContent := LContent + Format('Content-Type: %s', [LFile.FContentType]) + _CRLF + _CRLF;
               LStream.WriteBuffer(LContent[1], Length(LContent));
+              LFile.FFileStream.Position := 0;
               LStream.CopyFrom(TMemoryStream(LFile.FFileStream), LFile.FFileStream.Size);
+              LStream.WriteBuffer(_CRLF, Length(_CRLF));              
             end;
 
             LBound := _CRLF + '--' +LBound+ '--' + _CRLF;


### PR DESCRIPTION
Ajuste para upload de múltiplos arquivos em Lazarus.
Na procedure TRequestFPHTTPClient.ExecuteRequest(const AMethod: TMethodRequest);
Adicionado as últimas três linhas no bloco:
for LFieldName in FFiles.Keys do