### PR TITLE
Load Content while protocol error 500

### DIFF
--- a/src/RESTRequest4D.Request.Indy.pas
+++ b/src/RESTRequest4D.Request.Indy.pas
@@ -645,7 +645,10 @@ begin
   Self.ContentType('application/json');
   FRetries := 0;
   FIdMultiPartFormDataStream := TIdMultiPartFormDataStream.Create;
-  FIdHTTP.HTTPOptions:= [hoKeepOrigProtocol];
+  FIdHTTP.HTTPOptions:= [
+    hoKeepOrigProtocol,
+    hoWantProtocolErrorContent // This will force the Content when error 500 happens, not related with RaiseExceptionOn500
+    ];
 end;
 
 destructor TRequestIndy.Destroy;


### PR DESCRIPTION
Besides the RaiseExceptionOn500 property, Indy needs an extra HTTPOptions (hoWantProtocolErrorContent) to load the Content when error 500 is raised on server side, other wise the Content will not be loaded, so this extra HTTPOptions will load the Content doesn't matter the RaiseExceptionOn500 value