### PR TITLE
AddText - Delphi 10.4

### DIFF
--- a/src/RESTRequest4D.Request.Client.pas
+++ b/src/RESTRequest4D.Request.Client.pas
@@ -698,4 +698,3 @@ begin
 end;
 
 end.
-


### PR DESCRIPTION
Correção da chamada ao método Params.AddItem, na versão 10.4 o ContentType não existe como parâmetro deste método.

Necessários testes em versões acima para constatar se haverá a necessidade de alterar a versão na comparação da diretiva de versão de compilação (COMPILERVERSION)

Originado do issue: https://github.com/viniciussanchez/RESTRequest4Delphi/issues/250