### PR TITLE
Implementada conexão com certificado digital para o FPHTTPClient.

### DIFF
--- a/src/RESTRequest4D.Request.Contract.pas
+++ b/src/RESTRequest4D.Request.Contract.pas
@@ -115,6 +115,9 @@ type
     {$ENDIF}
     function Proxy(const AServer, APassword, AUsername: string; const APort: Integer): IRequest;
     function DeactivateProxy: IRequest;
+    {$IF DEFINED(FPC) and (not DEFINED(RR4D_INDY)) and (not DEFINED(RR4D_SYNAPSE))}
+    function Certificate(const AFileName, APassword: String): IRequest;
+    {$ENDIF}
     {$IF DEFINED(RR4D_INDY) or DEFINED(RR4D_ICS) or DEFINED(RR4D_SYNAPSE)}
     function CertFile(const APath: string): IRequest;
     function KeyFile(const APath: string): IRequest;


### PR DESCRIPTION
Vinicius, eu implementei o uso de certificado para autenticar usando o FPHTTPClient no Lazarus, vi que tinha a implementação para o Synapse, mas era usando PEM. No caso eu implementei com a possibilidade de usar o PFX direto com a senha do certificado. Se achar util é minha contribuição.

  response := TRequest.New
                      .BaseURL('Url')
                      .Accept('application/json')
                      .Certificate('ArquivoCertificado.pfx', 'SenhaCertificado')
                      .Get;


Obs: Testei em Linux e Windows, usando o Lazarus 3.2.2.