### PR TITLE
feat(tests): add complete integration test suite for Lazarus using FP…

### DIFF
--- a/src/RESTRequest4D.Request.FPHTTPClient.pas
+++ b/src/RESTRequest4D.Request.FPHTTPClient.pas
@@ -38,10 +38,13 @@ type
     FResponse: IResponse;
     FStreamSend: TStream;
     FRetries: Integer;
+    FRaiseExceptionOn500: Boolean;
     FCertificateFileName: String;
     FCertificatePassword: String;
     FOnBeforeExecute: TRR4DCallbackOnBeforeExecute;
     FOnAfterExecute: TRR4DCallbackOnAfterExecute;
+    FOnReceiveProgress: TRR4DCallbackOnProgress;
+    FOnSendProgress: TRR4DCallbackOnProgress;
     procedure ExecuteRequest(const AMethod: TMethodRequest);
     function AcceptEncoding: string; overload;
     function AcceptEncoding(const AAcceptEncoding: string): IRequest; overload;
@@ -68,6 +71,8 @@ type
     function Retry(const ARetries: Integer): IRequest;
     function OnBeforeExecute(const AOnBeforeExecute: TRR4DCallbackOnBeforeExecute): IRequest;
     function OnAfterExecute(const AOnAfterExecute: TRR4DCallbackOnAfterExecute): IRequest;
+    function OnReceiveProgress(const AOnProgress: TRR4DCallbackOnProgress): IRequest;
+    function OnSendProgress(const AOnProgress: TRR4DCallbackOnProgress): IRequest;
     function Get: IResponse;
     function Post: IResponse;
     function Put: IResponse;
@@ -105,6 +110,8 @@ type
   protected
     procedure DoAfterExecute(const Sender: TObject; const AResponse: IResponse); virtual;
     procedure DoBeforeExecute(const Sender: TFPHTTPClient); virtual;
+    procedure DoDataReceived(Sender: TObject; const ContentLength, CurrentPos: Int64); virtual;
+    procedure DoDataSent(Sender: TObject; const ContentLength, CurrentPos: Int64); virtual;
     procedure GetSocketHandler(Sender : TObject; Const UseSSL : Boolean; Out AHandler : TSocketHandler);
   public
     constructor Create;
@@ -114,7 +121,7 @@ type
 
 implementation
 
-uses RESTRequest4D.Response.FPHTTPClient, RESTRequest4D.Utils;
+uses RESTRequest4D.Response.FPHTTPClient;
 
 const
   _CRLF = #13#10;
@@ -142,6 +149,7 @@ var
   LBound, LContent, LFieldName: string;
   LFile: TFile;
   LStream: TRawByteStringStream;
+  LFirst: Boolean;
 begin
   LAttempts := FRetries + 1;
 
@@ -158,27 +166,42 @@ begin
             LBound := IntToHex(Random(MaxInt), 8) + '_multipart_boundary';
             ContentType('multipart/form-data; boundary=' + LBound);
 
+            LFirst := True;
+
             for LFieldName in FFields.Keys do
             begin
-              LContent := '--' + LBound + _CRLF;
-              LContent := LContent + Format('Content-Disposition: form-data; name="%s"' + _CRLF + _CRLF + '%s' + _CRLF, [LFieldName, FFields.Items[LFieldName]]);
+              if LFirst then
+              begin
+                LContent := '--' + LBound + _CRLF;
+                LFirst := False;
+              end
+              else
+                LContent := _CRLF + '--' + LBound + _CRLF;
+
+              LContent := LContent + Format('Content-Disposition: form-data; name="%s"' + _CRLF + _CRLF + '%s', [LFieldName, FFields.Items[LFieldName]]);
               LStream.WriteBuffer(PAnsiChar(LContent)^, Length(LContent));
             end;
 
             for LFieldName in FFiles.Keys do
             begin
               LFile := FFiles.Items[LFieldName];
-              LContent := '--' + LBound + _CRLF;
+              if LFirst then
+              begin
+                LContent := '--' + LBound + _CRLF;
+                LFirst := False;
+              end
+              else
+                LContent := _CRLF + '--' + LBound + _CRLF;
+
               LContent := LContent + Format('Content-Disposition: form-data; name="%s"; filename="%s"' + _CRLF, [LFieldName, ExtractFileName(LFile.FFileName)]);
               LContent := LContent + Format('Content-Type: %s', [LFile.FContentType]) + _CRLF + _CRLF;
-              LStream.WriteBuffer(LContent[1], Length(LContent));
+              LStream.WriteBuffer(PAnsiChar(LContent)^, Length(LContent));
               LFile.FFileStream.Position := 0;
-              LStream.CopyFrom(TMemoryStream(LFile.FFileStream), LFile.FFileStream.Size);
-              LStream.WriteBuffer(_CRLF, Length(_CRLF));              
+              LStream.CopyFrom(LFile.FFileStream, LFile.FFileStream.Size);
             end;
 
-            LBound := _CRLF + '--' +LBound+ '--' + _CRLF;
-            LStream.WriteBuffer(LBound[1], Length(LBound));
+            LBound := _CRLF + '--' + LBound + '--' + _CRLF;
+            LStream.WriteBuffer(PAnsiChar(LBound)^, Length(LBound));
             LStream.Position := 0;
             FFPHTTPClient.RequestBody := LStream;
           end
@@ -200,6 +223,8 @@ begin
         end;
 
         LAttempts := 0;
+        if FRaiseExceptionOn500 and (FResponse.StatusCode >= 500) then
+          raise Exception.Create(Format('HTTP/1.1 %d %s', [FResponse.StatusCode, FResponse.StatusText]));
       finally
         if Assigned(LStream) then
           LStream.Free;
@@ -279,12 +304,13 @@ end;
 
 function TRequestFPHTTPClient.RaiseExceptionOn500: Boolean;
 begin
-  Result := False;
+  Result := FRaiseExceptionOn500;
 end;
 
 function TRequestFPHTTPClient.RaiseExceptionOn500(const ARaiseException: Boolean): IRequest;
 begin
-  raise Exception.Create('Not implemented');
+  Result := Self;
+  FRaiseExceptionOn500 := ARaiseException;
 end;
 
 function TRequestFPHTTPClient.Resource: string;
@@ -340,6 +366,18 @@ function TRequestFPHTTPClient.OnAfterExecute(const AOnAfterExecute: TRR4DCallbac
 begin
   Result := Self;
   FOnAfterExecute := AOnAfterExecute;
+end;
+
+function TRequestFPHTTPClient.OnReceiveProgress(const AOnProgress: TRR4DCallbackOnProgress): IRequest;
+begin
+  Result := Self;
+  FOnReceiveProgress := AOnProgress;
+end;
+
+function TRequestFPHTTPClient.OnSendProgress(const AOnProgress: TRR4DCallbackOnProgress): IRequest;
+begin
+  Result := Self;
+  FOnSendProgress := AOnProgress;
 end;
 
 function TRequestFPHTTPClient.Get: IResponse;
@@ -517,7 +555,7 @@ var
 begin
   Result := Self;
   for I := 0 to ACookies.Count - 1 do
-    FFPHTTPClient.Cookies.Add(ACookies.Text[I]);
+    FFPHTTPClient.Cookies.Add(ACookies.Strings[I]);
 end;
 
 function TRequestFPHTTPClient.AddCookie(const ACookieName, ACookieValue: string): IRequest;
@@ -653,6 +691,32 @@ begin
     FOnBeforeExecute(Self);
 end;
 
+procedure TRequestFPHTTPClient.DoDataReceived(Sender: TObject; const ContentLength, CurrentPos: Int64);
+var
+  LAbort: Boolean;
+begin
+  if Assigned(FOnReceiveProgress) then
+  begin
+    LAbort := False;
+    FOnReceiveProgress(ContentLength, CurrentPos, LAbort);
+    if LAbort then
+      raise EAbort.Create('Operation aborted by user');
+  end;
+end;
+
+procedure TRequestFPHTTPClient.DoDataSent(Sender: TObject; const ContentLength, CurrentPos: Int64);
+var
+  LAbort: Boolean;
+begin
+  if Assigned(FOnSendProgress) then
+  begin
+    LAbort := False;
+    FOnSendProgress(ContentLength, CurrentPos, LAbort);
+    if LAbort then
+      raise EAbort.Create('Operation aborted by user');
+  end;
+end;
+
 procedure TRequestFPHTTPClient.GetSocketHandler(Sender: TObject; const UseSSL: Boolean; out AHandler: TSocketHandler);
 var
   SSLHandler: TOpenSSLSocketHandler;
@@ -679,6 +743,8 @@ begin
   FFPHTTPClient.AllowRedirect := True;
   FFPHTTPClient.RequestHeaders.Clear;
   FFPHTTPClient.ResponseHeaders.Clear;
+  FFPHTTPClient.OnDataReceived := DoDataReceived;
+  FRaiseExceptionOn500 := False;
 
   FHeaders := TstringList.Create;
   FParams := TstringList.Create;

--- a/tests/Lazarus/RESTRequest4D.Test.Request.pas
+++ b/tests/Lazarus/RESTRequest4D.Test.Request.pas
@@ -1,0 +1,384 @@
+unit RESTRequest4D.Test.Request;
+
+{$mode delphi}
+
+interface
+
+uses
+  fpcunit, testregistry, SysUtils, Classes, fpjson, jsonparser, syncobjs, RESTRequest4D, RESTRequest4D.Utils;
+
+type
+  TRESTRequest4DTest = class(TTestCase)
+  published
+    procedure TestFluidLifecycle;
+    procedure TestGetRequest;
+    procedure TestPostRequestWithJson;
+    procedure TestPutRequest;
+    procedure TestDeleteRequest;
+    procedure TestPatchRequest;
+    procedure TestAddHeaders;
+    procedure TestAddParams;
+    procedure TestAddUrlSegment;
+    procedure TestRaiseExceptionOn500;
+    procedure TestGetRequestAsync;
+    procedure TestTokenBearerAuthentication;
+    procedure TestCookies;
+    procedure TestMultipartFormData;
+    procedure TestAddBodyString;
+    procedure TestBenchmarkContentStream;
+  end;
+
+implementation
+
+var
+  GAsyncResponse: IResponse;
+  GAsyncEvent: TSimpleEvent;
+
+procedure AsyncCallback(const Req: IRequest; const Res: IResponse);
+begin
+  GAsyncResponse := Res;
+  GAsyncEvent.SetEvent;
+end;
+
+{ TRESTRequest4DTest }
+
+procedure TRESTRequest4DTest.TestFluidLifecycle;
+var
+  LResponse: IResponse;
+begin
+  LResponse := TRequest.New
+    .BaseURL('https://httpbin.org')
+    .Resource('get')
+    .Get;
+
+  AssertNotNull('A resposta não deve ser nula', LResponse);
+  AssertEquals('StatusCode deve ser 200', 200, LResponse.StatusCode);
+  AssertTrue('Content não deve ser vazio', LResponse.Content <> '');
+end;
+
+procedure TRESTRequest4DTest.TestGetRequest;
+var
+  LResponse: IResponse;
+  LJson: TJSONObject;
+begin
+  LResponse := TRequest.New
+    .BaseURL('https://httpbin.org')
+    .Resource('get')
+    .Get;
+
+  AssertEquals(200, LResponse.StatusCode);
+  AssertTrue(LResponse.Content <> '');
+  
+  LJson := LResponse.JSONValue as TJSONObject;
+  AssertNotNull('JSON retornado não deve ser nulo', LJson);
+  AssertNotNull('JSON deve conter campo URL', LJson.Find('url'));
+end;
+
+procedure TRESTRequest4DTest.TestPostRequestWithJson;
+var
+  LResponse: IResponse;
+  LBody: TJSONObject;
+  LJson: TJSONObject;
+  LData: TJSONObject;
+begin
+  LBody := TJSONObject.Create;
+  LBody.Add('nome', 'RESTRequest4Delphi');
+  LBody.Add('status', 'OK');
+
+  LResponse := TRequest.New
+    .BaseURL('https://httpbin.org')
+    .Resource('post')
+    .AddBody(LBody)
+    .Post;
+
+  AssertEquals(200, LResponse.StatusCode);
+  AssertTrue(LResponse.Content <> '');
+
+  LJson := LResponse.JSONValue as TJSONObject;
+  AssertNotNull(LJson);
+  
+  LData := LJson.Find('json') as TJSONObject;
+  AssertNotNull('JSON enviado deve estar no campo json da resposta', LData);
+  AssertEquals('RESTRequest4Delphi', LData.Strings['nome']);
+end;
+
+procedure TRESTRequest4DTest.TestPutRequest;
+var
+  LResponse: IResponse;
+  LBody: TJSONObject;
+  LJson: TJSONObject;
+  LData: TJSONObject;
+begin
+  LBody := TJSONObject.Create;
+  LBody.Add('param_put', 'valor_put');
+
+  LResponse := TRequest.New
+    .BaseURL('https://httpbin.org')
+    .Resource('put')
+    .AddBody(LBody)
+    .Put;
+
+  AssertEquals(200, LResponse.StatusCode);
+  LJson := LResponse.JSONValue as TJSONObject;
+  LData := LJson.Find('json') as TJSONObject;
+  AssertNotNull(LData);
+  AssertEquals('valor_put', LData.Strings['param_put']);
+end;
+
+procedure TRESTRequest4DTest.TestDeleteRequest;
+var
+  LResponse: IResponse;
+begin
+  LResponse := TRequest.New
+    .BaseURL('https://httpbin.org')
+    .Resource('delete')
+    .Delete;
+
+  AssertEquals(200, LResponse.StatusCode);
+end;
+
+procedure TRESTRequest4DTest.TestPatchRequest;
+var
+  LResponse: IResponse;
+  LBody: TJSONObject;
+  LJson: TJSONObject;
+  LData: TJSONObject;
+begin
+  LBody := TJSONObject.Create;
+  LBody.Add('param_patch', 'valor_patch');
+
+  LResponse := TRequest.New
+    .BaseURL('https://httpbin.org')
+    .Resource('patch')
+    .AddBody(LBody)
+    .Patch;
+
+  AssertEquals(200, LResponse.StatusCode);
+  LJson := LResponse.JSONValue as TJSONObject;
+  LData := LJson.Find('json') as TJSONObject;
+  AssertNotNull(LData);
+  AssertEquals('valor_patch', LData.Strings['param_patch']);
+end;
+
+procedure TRESTRequest4DTest.TestAddHeaders;
+var
+  LResponse: IResponse;
+  LJson: TJSONObject;
+  LHeaders: TJSONObject;
+begin
+  LResponse := TRequest.New
+    .BaseURL('https://httpbin.org')
+    .Resource('headers')
+    .AddHeader('X-Test-Library', 'RESTRequest4Delphi')
+    .Get;
+
+  AssertEquals(200, LResponse.StatusCode);
+  
+  LJson := LResponse.JSONValue as TJSONObject;
+  LHeaders := LJson.Find('headers') as TJSONObject;
+  AssertNotNull(LHeaders);
+  AssertEquals('RESTRequest4Delphi', LHeaders.Strings['X-Test-Library']);
+end;
+
+procedure TRESTRequest4DTest.TestAddParams;
+var
+  LResponse: IResponse;
+  LJson: TJSONObject;
+  LArgs: TJSONObject;
+begin
+  LResponse := TRequest.New
+    .BaseURL('https://httpbin.org')
+    .Resource('get')
+    .AddParam('search', 'delphi')
+    .AddParam('page', '1')
+    .Get;
+
+  AssertEquals(200, LResponse.StatusCode);
+  
+  LJson := LResponse.JSONValue as TJSONObject;
+  LArgs := LJson.Find('args') as TJSONObject;
+  AssertNotNull(LArgs);
+  AssertEquals('delphi', LArgs.Strings['search']);
+  AssertEquals('1', LArgs.Strings['page']);
+end;
+
+procedure TRESTRequest4DTest.TestAddUrlSegment;
+var
+  LResponse: IResponse;
+  LJson: TJSONObject;
+begin
+  LResponse := TRequest.New
+    .BaseURL('https://httpbin.org')
+    .Resource('anything/:id')
+    .AddUrlSegment('id', '123')
+    .Get;
+
+  AssertEquals(200, LResponse.StatusCode);
+  
+  LJson := LResponse.JSONValue as TJSONObject;
+  AssertTrue('URL final deve conter o segmento id substituído', Pos('/anything/123', LJson.Strings['url']) > 0);
+end;
+
+procedure TRESTRequest4DTest.TestRaiseExceptionOn500;
+var
+  LRequest: IRequest;
+  LSuccess: Boolean;
+  LResponse: IResponse;
+begin
+  LRequest := TRequest.New
+    .BaseURL('https://httpbin.org')
+    .Resource('status/500')
+    .RaiseExceptionOn500(True);
+
+  LSuccess := False;
+  try
+    LResponse := LRequest.Get;
+    Fail('Não disparou exceção. Status retornado: ' + IntToStr(LResponse.StatusCode));
+  except
+    on E: Exception do
+      LSuccess := True;
+  end;
+  AssertTrue('Deveria ter disparado uma exceção para o erro 500', LSuccess);
+end;
+
+procedure TRESTRequest4DTest.TestGetRequestAsync;
+var
+  LRequest: IRequest;
+  LTimeout: Cardinal;
+begin
+  GAsyncEvent := TSimpleEvent.Create;
+  try
+    GAsyncResponse := nil;
+    LRequest := TRequest.New
+      .BaseURL('https://httpbin.org')
+      .Resource('get');
+
+    LRequest.GetAsync(AsyncCallback);
+
+    LTimeout := 0;
+    while (GAsyncEvent.WaitFor(50) = wrTimeout) and (LTimeout < 10000) do
+    begin
+      CheckSynchronize(10);
+      Inc(LTimeout, 60);
+    end;
+
+    AssertNotNull('A resposta do callback assíncrono não deve ser nula. Erro interno: ' + TAsyncRequestThread.LastError, GAsyncResponse);
+    AssertEquals('StatusCode deve ser 200', 200, GAsyncResponse.StatusCode);
+    AssertTrue('Content não deve ser vazio', GAsyncResponse.Content <> '');
+  finally
+    GAsyncEvent.Free;
+  end;
+end;
+
+procedure TRESTRequest4DTest.TestTokenBearerAuthentication;
+var
+  LResponse: IResponse;
+begin
+  LResponse := TRequest.New
+    .BaseURL('https://httpbin.org')
+    .Resource('bearer')
+    .TokenBearer('token123')
+    .Get;
+
+  AssertEquals(200, LResponse.StatusCode);
+end;
+
+procedure TRESTRequest4DTest.TestCookies;
+var
+  LResponse: IResponse;
+  LJson: TJSONObject;
+  LCookies: TJSONObject;
+begin
+  LResponse := TRequest.New
+    .BaseURL('https://httpbin.org')
+    .Resource('cookies')
+    .AddCookie('c1', 'v1')
+    .Get;
+
+  AssertEquals(200, LResponse.StatusCode);
+  LJson := LResponse.JSONValue as TJSONObject;
+  LCookies := LJson.Find('cookies') as TJSONObject;
+  AssertNotNull(LCookies);
+  AssertEquals('v1', LCookies.Strings['c1']);
+end;
+
+procedure TRESTRequest4DTest.TestMultipartFormData;
+var
+  LResponse: IResponse;
+  LJson: TJSONObject;
+  LForm: TJSONObject;
+begin
+  LResponse := TRequest.New
+    .BaseURL('https://httpbin.org')
+    .Resource('post')
+    .AddField('campo1', 'valor1')
+    .AddField('campo2', 'valor2')
+    .Post;
+
+  AssertEquals(200, LResponse.StatusCode);
+  LJson := LResponse.JSONValue as TJSONObject;
+  AssertNotNull('JSON retornado não deve ser nulo. Conteúdo: ' + LResponse.Content, LJson);
+  LForm := LJson.Find('form') as TJSONObject;
+  AssertNotNull(LForm);
+  AssertNotNull('campo1 nao encontrado no form. JSON: ' + LResponse.Content, LForm.Find('campo1'));
+  AssertEquals('valor1', LForm.Strings['campo1']);
+  AssertNotNull('campo2 nao encontrado no form. JSON: ' + LResponse.Content, LForm.Find('campo2'));
+  AssertEquals('valor2', LForm.Strings['campo2']);
+end;
+
+procedure TRESTRequest4DTest.TestAddBodyString;
+var
+  LResponse: IResponse;
+  LJson: TJSONObject;
+  LData: string;
+begin
+  LResponse := TRequest.New
+    .BaseURL('https://httpbin.org')
+    .Resource('post')
+    .AddBody('Texto Bruto de Teste')
+    .Post;
+
+  AssertEquals(200, LResponse.StatusCode);
+  LJson := LResponse.JSONValue as TJSONObject;
+  LData := LJson.Strings['data'];
+  AssertEquals('Texto Bruto de Teste', LData);
+end;
+
+procedure TRESTRequest4DTest.TestBenchmarkContentStream;
+var
+  LResponse: IResponse;
+  I: Integer;
+  LStart: Cardinal;
+  LStream: TStream;
+  LTime: Cardinal;
+  LFile: TStringList;
+begin
+  LResponse := TRequest.New
+    .BaseURL('https://httpbin.org')
+    .Resource('bytes/50000')
+    .Get;
+
+  AssertEquals(200, LResponse.StatusCode);
+
+  LStart := TThread.GetTickCount;
+  for I := 1 to 20000 do
+  begin
+    LStream := LResponse.ContentStream;
+    if LStream.Size <> 50000 then
+      Fail('Tamanho incorreto do stream');
+  end;
+  LTime := TThread.GetTickCount - LStart;
+
+  LFile := TStringList.Create;
+  try
+    LFile.Add('Tempo gasto para 20.000 acessos ao ContentStream: ' + IntToStr(LTime) + ' ms');
+    LFile.SaveToFile('benchmark.txt');
+  finally
+    LFile.Free;
+  end;
+end;
+
+initialization
+  RegisterTest(TRESTRequest4DTest);
+
+end.

--- a/tests/Lazarus/RESTRequest4DTests.lpi
+++ b/tests/Lazarus/RESTRequest4DTests.lpi
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CONFIG>
+  <ProjectOptions>
+    <Version Value="12"/>
+    <PathDelim Value="\"/>
+    <General>
+      <Flags>
+        <CompatibilityMode Value="True"/>
+      </Flags>
+      <SessionStorage Value="InProjectDir"/>
+      <Title Value="RESTRequest4DTests"/>
+      <UseAppBundle Value="False"/>
+      <ResourceType Value="res"/>
+    </General>
+    <BuildModes Count="1">
+      <Item1 Name="Default" Default="True"/>
+    </BuildModes>
+    <PublishOptions>
+      <Version Value="2"/>
+      <UseFileFilters Value="True"/>
+    </PublishOptions>
+    <RunParams>
+      <FormatVersion Value="2"/>
+    </RunParams>
+    <RequiredPackages Count="1">
+      <Item1>
+        <PackageName Value="FCL"/>
+      </Item1>
+    </RequiredPackages>
+    <Units Count="2">
+      <Unit0>
+        <Filename Value="RESTRequest4DTests.lpr"/>
+        <IsPartOfProject Value="True"/>
+      </Unit0>
+      <Unit1>
+        <Filename Value="RESTRequest4D.Test.Request.pas"/>
+        <IsPartOfProject Value="True"/>
+      </Unit1>
+    </Units>
+  </ProjectOptions>
+  <CompilerOptions>
+    <Version Value="11"/>
+    <PathDelim Value="\"/>
+    <Target>
+      <Filename Value="RESTRequest4DTests"/>
+    </Target>
+    <SearchPaths>
+      <IncludeFiles Value="$(ProjOutDir)"/>
+      <OtherUnitFiles Value="..\..\src"/>
+      <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+    </SearchPaths>
+  </CompilerOptions>
+</CONFIG>

--- a/tests/Lazarus/RESTRequest4DTests.lpr
+++ b/tests/Lazarus/RESTRequest4DTests.lpr
@@ -1,0 +1,16 @@
+program RESTRequest4DTests;
+
+{$mode objfpc}{$H+}
+
+uses
+  Classes, SysUtils, consoletestrunner, RESTRequest4D.Test.Request;
+
+var
+  Application: TTestRunner;
+begin
+  Application := TTestRunner.Create(nil);
+  Application.Initialize;
+  Application.Title := 'RESTRequest4Delphi Tests';
+  Application.Run;
+  Application.Free;
+end.

--- a/tests/Lazarus/benchmark.txt
+++ b/tests/Lazarus/benchmark.txt
@@ -1,0 +1,1 @@
+Tempo gasto para 20.000 acessos ao ContentStream: 47 ms


### PR DESCRIPTION
# feat(tests): add Lazarus test suite (FPCUnit) and fix core FPHTTPClient bugs

## 🚀 O que este PR introduz?
Este PR adiciona uma suíte de testes de integração e unidade completa para o **Lazarus/FPC**, utilizando o framework nativo **FPCUnit** (console runner) e mapeando o parser de JSON padrão do Free Pascal (`fpjson`). 

Além disso, foram identificados e corrigidos problemas críticos de paridade de recursos e bugs de formatação no motor HTTP padrão do FPC (`FPHTTPClient`).

---

## 🐛 Correções de Bugs e Melhorias no Motor `FPHTTPClient`

* **Correção de Bug Crítico no Envio de Cookies**: O método `AddCookies` estava utilizando a propriedade `.Text[I]`, o que extraía caracteres individuais da string list (ex: enviando apenas `'c'` em vez de `'c1=v1'`) e gerava erro `400 Bad Request`. Corrigido para `ACookies.Strings[I]`.
* **Correção na Formatação de Multipart Form-Data (RFC 7578)**: Corrigido o vazamento de quebras de linha `\r\n` (CRLF) no final do valor de campos textuais e streams de arquivos enviados no corpo do request, garantindo que o servidor remoto interprete os valores limpos.
* **Suporte a Callbacks de Progresso**: Implementadas as assinaturas `OnReceiveProgress` e `OnSendProgress` e efetuado o binding com o evento nativo `OnDataReceived` do `TFPHTTPClient` para reportar o progresso de downloads (o evento `OnDataSent` não existe no FPC 3.2.2 e foi mantido como stub para compilação).
* **Controle de Erro HTTP 500**: Adicionado o suporte correto ao método `RaiseExceptionOn500`, que lança exceção com o código e status apropriados caso o retorno HTTP seja `>= 500`.
* **Correção de Compilação no FPC**: Removida a referência duplicada à unit `RESTRequest4D.Utils` na seção `implementation` do arquivo `RESTRequest4D.Request.FPHTTPClient.pas` que gerava erros de compilação.

---

## 🧪 Suíte de Testes Lazarus (FPCUnit)

Os testes foram adicionados no diretório `tests/Lazarus` e cobrem todas as 16 funcionalidades do ecossistema REST (GET, POST, PUT, DELETE, PATCH, URL Segments, Query Params, Headers, Cookies, Authentication, Multipart uploads, Threads Assíncronas e Performance do ContentStream).

**Resultado da execução contra API real (httpbin.org):**
* **Total de Testes Executados**: 16
* **Resultados de Sucesso**: 16 (100% Passed)
* **Erros / Falhas**: 0
* **Tempo Total de Execução (Rede)**: 12.309s

---

## 🛠️ Como executar os testes criados?

Para compilar e rodar os testes via terminal:

```powershell
# Compilar projeto pelo compilador do Lazarus (lazbuild)
C:\lazarus\lazbuild.exe tests/Lazarus/RESTRequest4DTests.lpi

# Executar os testes automatizados com relatório XML no console
tests/Lazarus/RESTRequest4DTests.exe -a
