### PR TITLE
fix(utils): resolve compilation error on non-Windows platforms (issue…

### DIFF
--- a/src/RESTRequest4D.Utils.pas
+++ b/src/RESTRequest4D.Utils.pas
@@ -9,8 +9,14 @@ interface
 uses
   {$IFDEF FPC}
     Classes, SysUtils,
+    {$IFDEF MSWINDOWS}
+    ActiveX,
+    {$ENDIF}
   {$ELSE}
-    System.Classes, System.SysUtils, Winapi.ActiveX,
+    System.Classes, System.SysUtils,
+    {$IFDEF MSWINDOWS}
+    Winapi.ActiveX,
+    {$ENDIF}
   {$ENDIF}
   RESTRequest4D.Request.Contract,
   RESTRequest4D.Response.Contract;
@@ -108,7 +114,7 @@ end;
 procedure TAsyncRequestThread.Execute;
 begin
   LastError := '';
-  {$IFNDEF FPC}
+  {$IFDEF MSWINDOWS}
   CoInitialize(nil);
   {$ENDIF}
   try
@@ -131,7 +137,7 @@ begin
       end;
     end;
   finally
-    {$IFNDEF FPC}
+    {$IFDEF MSWINDOWS}
     CoUninitialize;
     {$ENDIF}
   end;


### PR DESCRIPTION
## Correção da Issue #279: Falha de compilação em plataformas não-Windows (F2613 Unit 'Winapi.ActiveX' not found)

### Descrição
Este Pull Request corrige um problema que impedia a compilação do `RESTRequest4Delphi` ao utilizar compiladores Delphi voltados para plataformas que não sejam Windows (como Linux, macOS, Android e iOS). 

Anteriormente, a unit `RESTRequest4D.Utils.pas` assumia incorretamente que se o compilador não era FPC (Lazarus), a plataforma de destino seria sempre Windows (`{$IFNDEF FPC}`), incluindo incondicionalmente a unit `Winapi.ActiveX` e chamando funções de COM (`CoInitialize` / `CoUninitialize`).

### Alterações Realizadas
- **`src/RESTRequest4D.Utils.pas`**:
  - Restringida a importação de `Winapi.ActiveX` (no Delphi) e `ActiveX` (no Lazarus/FPC) apenas quando compilando para a plataforma Windows (`{$IFDEF MSWINDOWS}`).
  - Envolvido o controle de inicialização do COM (`CoInitialize`/`CoUninitialize`) sob a diretiva `{$IFDEF MSWINDOWS}` para que o subsistema COM seja ativado apenas no ecossistema Windows.

### Testes e Validação
A compilação do projeto de testes foi validada com 100% de sucesso nas seguintes plataformas locais:
- Delphi 10 Seattle
- Delphi 11 Alexandria
- Delphi 12 Athens
- Delphi 13 Florence
- Lazarus/FPC 3.2.2 (compilação completa do `RESTRequest4DTests.lpi`)

Isso garante compatibilidade multiplataforma contínua tanto no Delphi quanto no FPC.
