### PR TITLE
corrige diretivas de compilação - indy

### DIFF
--- a/src/RESTRequest4D.Request.Contract.pas
+++ b/src/RESTRequest4D.Request.Contract.pas
@@ -115,7 +115,7 @@ type
       function Trace: IResponse;
     {$ENDIF}
 
-	{$IF NOT DEFINED(RR4D_SYNAPSE) or IF NOT DEFINED(RR4D_ICS)}
+	{$IF NOT (DEFINED(RR4D_SYNAPSE) OR NOT DEFINED(RR4D_ICS))}
     function AddFieldFormData(const AFieldName: string; const AValue: string): IRequest;
     function AddFieldXWwwForm(const AFieldName: string; const AValue: string): IRequest;
     {$ENDIF}

--- a/src/RESTRequest4D.Request.Indy.pas
+++ b/src/RESTRequest4D.Request.Indy.pas
@@ -216,11 +216,15 @@ var
 begin
   cookies := TStringList.Create;
   try
-  {$IF COMPILERVERSION <= 28.0}
-    cookies.Values[ACookieName] := ACookieValue;
-  {$ELSE}
-    cookies.AddPair(ACookieName, ACookieValue);
-  {$ENDIF}
+    {$IFDEF FPC}
+      cookies.Values[ACookieName] := ACookieValue;
+    {$ELSE}
+      {$IF COMPILERVERSION <= 28.0}
+        cookies.Values[ACookieName] := ACookieValue;
+      {$ELSE}
+        cookies.AddPair(ACookieName, ACookieValue);
+      {$ENDIF}
+    {$ENDIF}
   Result := AddCookies(cookies);
   except
     cookies.Free;
@@ -770,13 +774,18 @@ begin
   FIdSSLIOHandlerSocketOpenSSL := TIdSSLIOHandlerSocketOpenSSL.Create;
   FIdHTTP.IOHandler := FIdSSLIOHandlerSocketOpenSSL;
 
-  {$IF COMPILERVERSION > 28.0}
-    FIdSSLIOHandlerSocketOpenSSL.SSLOptions.SSLVersions := FIdSSLIOHandlerSocketOpenSSL.SSLOptions.SSLVersions +
-      [sslvSSLv2, sslvSSLv23, sslvSSLv3, sslvTLSv1, sslvTLSv1_1, sslvTLSv1_2];
-  {$ELSE}
-    FIdSSLIOHandlerSocketOpenSSL.SSLOptions.SSLVersions := FIdSSLIOHandlerSocketOpenSSL.SSLOptions.SSLVersions +
-      [sslvTLSv1, sslvTLSv1_1, sslvTLSv1_2];
-  {$ENDIF}
+  {$IFDEF FPC}
+     FIdSSLIOHandlerSocketOpenSSL.SSLOptions.SSLVersions := FIdSSLIOHandlerSocketOpenSSL.SSLOptions.SSLVersions +
+       [sslvSSLv2, sslvSSLv23, sslvSSLv3, sslvTLSv1, sslvTLSv1_1, sslvTLSv1_2];
+   {$ELSE}
+     {$IF COMPILERVERSION > 28.0}
+       FIdSSLIOHandlerSocketOpenSSL.SSLOptions.SSLVersions := FIdSSLIOHandlerSocketOpenSSL.SSLOptions.SSLVersions +
+         [sslvSSLv2, sslvSSLv23, sslvSSLv3, sslvTLSv1, sslvTLSv1_1, sslvTLSv1_2];
+     {$ELSE}
+       FIdSSLIOHandlerSocketOpenSSL.SSLOptions.SSLVersions := FIdSSLIOHandlerSocketOpenSSL.SSLOptions.SSLVersions +
+         [sslvTLSv1, sslvTLSv1_1, sslvTLSv1_2];
+     {$ENDIF}
+   {$ENDIF}
 
   FIdSSLIOHandlerSocketOpenSSL.OnStatusInfoEx := Self.OnStatusInfoEx;
 


### PR DESCRIPTION
- RESTRequest4D.Request.Contract.pas: Ajuste na lógica dos defined.
- RESTRequest4D.Request.Indy.pas: Em parte do código da engine Indy estava sendo usada a diretiva "COMPILERVERSION", disponível apenas no Delphi, causando erro ao compilar usando o FPC.